### PR TITLE
Parse Twitch URL in settings input

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -111,7 +111,15 @@ if (saveBtn) {
         const restartInput = document.getElementById('restart-time');
 
         if (channelInput && channelInput.value) {
-            localStorage.setItem('channel_name', channelInput.value.trim());
+            let channelName = channelInput.value.trim();
+            if (channelName.includes('twitch.tv/')) {
+                const parts = channelName.split('twitch.tv/');
+                if (parts.length > 1) {
+                    channelName = parts[1].split('/')[0].split('?')[0];
+                    channelInput.value = channelName;
+                }
+            }
+            localStorage.setItem('channel_name', channelName);
         }
 
         if (restartInput && restartInput.value) {


### PR DESCRIPTION
Implemented logic in `js/init.js` to automatically parse and clean the Twitch channel name when the user saves settings. If a full URL is entered, it extracts the nickname, updates the input field, and saves only the nickname. Verified with test scripts and frontend automation.

---
*PR created automatically by Jules for task [304975580313915771](https://jules.google.com/task/304975580313915771) started by @AnnaCodit*