### PR TITLE
Add support for loading external CSS via 'cssFile' parameter

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -172,10 +172,10 @@ function loadSettings() {
     if (cssFile) {
         try {
             let urlString = cssFile;
-            // Если ссылка не начинается с http, https или не является протокол-относительной
-            if (!/^(https?:)?\/\//.test(urlString)) {
+            // Если ссылка не начинается с http://, https:// или //
+            if (!urlString.startsWith('http://') && !urlString.startsWith('https://') && !urlString.startsWith('//')) {
                 urlString = 'https://' + urlString;
-            }
+            }            
 
             const cssUrl = new URL(urlString);
             cssUrl.searchParams.set('slv_timestamp', Date.now());


### PR DESCRIPTION
Добавлена возможность динамически подключать внешний CSS-файл с помощью GET-параметра `cssFile`. 

- Если передается неполная ссылка (например `website.com/some.css`), она автоматически дополняется префиксом `https://`.
- Для обхода кеширования к ссылке динамически добавляется параметр `slv_timestamp` (с учетом того, есть ли в ссылке уже другие параметры).
- Созданный элемент `<link>` добавляется в конец `<head>`, чтобы его стили перекрывали основные стили приложения.

---
*PR created automatically by Jules for task [5862216131934760720](https://jules.google.com/task/5862216131934760720) started by @AnnaCodit*