### PR TITLE
Таблица лидеров с медалями

### DIFF
--- a/js/leaderboard.js
+++ b/js/leaderboard.js
@@ -24,7 +24,7 @@ function updateLeaderboard(winnerName) {
 
 function renderLeaderboard() {
     const data = getLeaderboardData();
-    listContainer = document.querySelector('#leaderboard .list');
+    const listContainer = document.querySelector('#leaderboard .list');
     if (!listContainer) return;
 
     listContainer.innerHTML = '';
@@ -35,30 +35,40 @@ function renderLeaderboard() {
         .slice(0, 5); // Take top 5
 
     if (sortedWinners.length === 0) {
-        listContainer.innerHTML = '<div style="text-align: center; color: #777;">Пока нет победителей</div>';
+        listContainer.innerHTML =
+            '<div style="text-align:center;color:#777;">Пока нет победителей</div>';
         return;
     }
 
-    sortedWinners.forEach((item, index) => {
-        const name = item[0];
-        const wins = item[1];
+    const medals = ['🥇', '🥈', '🥉'];
+
+    let medalLevel = 0;
+    let previousWins = null;
+
+    sortedWinners.forEach(([name, wins]) => {
+        if (previousWins !== null && wins !== previousWins) {
+            medalLevel++;
+        }
+
+        previousWins = wins;
 
         const itemDiv = document.createElement('div');
         itemDiv.className = 'leaderboard-item';
 
-        const rankDiv = document.createElement('div');
-        rankDiv.className = 'rank';
-        rankDiv.textContent = `#${index + 1}`;
-        itemDiv.appendChild(rankDiv);
-
         const nameDiv = document.createElement('div');
         nameDiv.className = 'name';
-        nameDiv.textContent = name; // Safe assignment
-        itemDiv.appendChild(nameDiv);
+        nameDiv.textContent = name;
 
         const scoreDiv = document.createElement('div');
         scoreDiv.className = 'score';
-        scoreDiv.textContent = `${wins} 🏆`;
+
+        const medal = medals[medalLevel] || '';
+
+        scoreDiv.textContent = medal
+            ? `${wins} ${medal}`
+            : `${wins}`;
+
+        itemDiv.appendChild(nameDiv);
         itemDiv.appendChild(scoreDiv);
 
         listContainer.appendChild(itemDiv);


### PR DESCRIPTION
Привет, немного переделал таблицу лидеров. Убрал порядковые номера, кубки и добавил 3 типа медалей: золото, серебро, бронза. Победители с одинаковым количеством побед делят занятое место. т.к. новый победитель всегда ставится "сверху" над теми у кого такое же количество побед. 
https://www.twitch.tv/videos/2785498228?t=2h15m22s
Вот, как пример, из-за этого пострадал zengard61. Стас выиграл одну из последних игр он был "сверху" и получил на 5 мемекоинов больше. Считаю, zengard61 тоже должен был получить 15, он не на 3 месте, а делит 2 вместе с Стасом.
<details>
<summary>Как это будет выглядеть (картинка)</summary>
<img width="504" height="429" alt="image" src="https://github.com/user-attachments/assets/cbd9d833-4110-4ad2-aea3-32550887effc" />
</details>