### PR TITLE
Выбор бэкенда (kontekstno / wordgun) и устойчивость к сбоям

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test/
 ._*
 desktop.ini
 node_modules/
+.idea

--- a/css/settings.css
+++ b/css/settings.css
@@ -89,6 +89,37 @@
     outline: 2px solid rgba(255, 0, 0, 0.5);
 }
 
+/* Match the dropdown to the text/number inputs, with a themed caret */
+#settings .setting select {
+    width: 100%;
+    max-width: 300px;
+    padding: 10px;
+    padding-right: 36px;
+    border-radius: 5px;
+    border: 1px solid #444;
+    background-color: #333;
+    color: #FFF;
+    font-size: 18px;
+    font-family: inherit;
+    cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2 4.5 6 8.5 10 4.5' fill='none' stroke='%23bbb' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 12px;
+}
+
+#settings .setting select:focus {
+    outline: 2px solid #777;
+}
+
+#settings .setting select option {
+    background-color: #333;
+    color: #FFF;
+}
+
 #settings .setting:last-child {
     margin-bottom: 0;
 }

--- a/css/settings.css
+++ b/css/settings.css
@@ -120,6 +120,18 @@
     color: #FFF;
 }
 
+#settings .backend-warning {
+    margin-top: 8px;
+    max-width: 300px;
+    padding: 8px 10px;
+    border-radius: 5px;
+    border: 1px solid #8a6d1a;
+    background: rgba(255, 193, 7, 0.12);
+    color: #ffd87a;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
 #settings .setting:last-child {
     margin-bottom: 0;
 }

--- a/index.html
+++ b/index.html
@@ -87,6 +87,13 @@
                             <div class="title">Перезапуск игры после победы (секунды)</div>
                             <input type="number" id="restart-time" name="restart_time" placeholder="20" min="0">
                         </div>
+                        <div class="setting">
+                            <div class="title">Источник слов (бэкенд)</div>
+                            <select id="game-backend" name="game_backend">
+                                <option value="kontekstno">контекстно.рф</option>
+                                <option value="wordgun">wordgun.ru</option>
+                            </select>
+                        </div>
                     </div>
                     <div class="ui-col">
                         <div class="setting checkbox-container">

--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@
                                 <option value="kontekstno">контекстно.рф</option>
                                 <option value="wordgun">wordgun.ru</option>
                             </select>
+                            <div id="backend-warning" class="backend-warning" style="display: none;">
+                                ⚠️ wordgun.ru может работать некорректно с российских IP-адресов. Если игра не запускается, используйте VPN или выберите контекстно.рф.
+                            </div>
                         </div>
                     </div>
                     <div class="ui-col">

--- a/index.html
+++ b/index.html
@@ -229,8 +229,8 @@
     <script src="js/background.js?v=__ASSETS_VERSION__"></script>
     <script src="js/leaderboard.js?v=__ASSETS_VERSION__"></script>
     <script src="js/tips.js?v=__ASSETS_VERSION__"></script>
-    <script src="js/init.js?v=__ASSETS_VERSION__"></script>
     <script src="js/confetti.js?v=__ASSETS_VERSION__"></script>
+    <script src="js/init.js?v=__ASSETS_VERSION__"></script>
     <script src="js/analytics.js?v=__ASSETS_VERSION__"></script>
 </body>
 

--- a/js/api.js
+++ b/js/api.js
@@ -252,9 +252,8 @@ const GAME_BACKENDS = {
 
         async tip(gameId, bestRank) {
             // /hint returns a word strictly closer to the secret than best_rank
-            // (clamped to [2, vocab_size] server-side). The optional `revealed`
-            // field is intentionally omitted. best_rank is left out until we have a
-            // finite best, so the server returns a far first hint.
+            // (clamped to [2, vocab_size] server-side). best_rank is left out until
+            // we have a finite best, so the server returns a far first hint.
             const body = { token: gameId };
             if (Number.isFinite(bestRank)) body.best_rank = bestRank;
             const result = await wordgun_request('/hint', { method: 'POST', body });

--- a/js/api.js
+++ b/js/api.js
@@ -166,6 +166,7 @@ const GAME_BACKENDS = {
         id: 'kontekstno',
         label: 'контекстно.рф',
         supportsTips: true,
+        maxDistance: kontekstno_api_tips_max_distance,
 
         async createGame() {
             const data = await kontekstno_query({ method: 'random-challenge' });
@@ -207,23 +208,31 @@ const GAME_BACKENDS = {
             return { distance: result.distance };
         },
 
-        async tip(gameId, lastRank) {
+        async tip(gameId, bestRank) {
+            // надо фейкануть дальность лучшего слова чтобы он не уполовинивал близость, а чуть подальше. Например мальтипликатор 1.5 даст 25% приближения вместо 50%
+            let fine_tuned_distance = Math.floor(bestRank * 1.5);
+            // иначе она всегда будет kontekstno_api_max_distance, это магическое число апишки, большую дальность она сбрасывает к kontekstno_api_max_distance
+            if (fine_tuned_distance > kontekstno_api_tips_max_distance) fine_tuned_distance = kontekstno_api_tips_max_distance;
+            // edge case. Если логика апишки (Math.ceil(fine_tuned_distance / 2)) даст такое же значение, как и текущий best_found_distance, то не фейкаем его, чтобы всё не циклилось
+            if (Math.ceil(fine_tuned_distance / 2) == bestRank) fine_tuned_distance = bestRank;
+
             const result = await kontekstno_query({
                 method: 'tip',
                 challenge_id: gameId,
-                last_word_rank: lastRank
+                last_word_rank: fine_tuned_distance
             });
             return { word: result?.word, distance: result?.distance };
         }
     },
 
     // wordgun.ru — stateless API (see public-api-v1.md). The game lives inside an
-    // opaque token; a guess returns { in_vocab, rank }. No hint endpoint and the
-    // secret word is never disclosed.
+    // opaque token; a guess returns { in_vocab, rank }. The secret word is never
+    // disclosed, but a hint endpoint reveals a word closer than your best rank.
     wordgun: {
         id: 'wordgun',
         label: 'wordgun.ru',
-        supportsTips: false,
+        supportsTips: true,
+        maxDistance: Infinity,
 
         async createGame() {
             const data = await wordgun_request('/games', { method: 'POST' });
@@ -241,7 +250,17 @@ const GAME_BACKENDS = {
             return { distance: result.in_vocab ? result.rank : undefined };
         },
 
-        tip: null
+        async tip(gameId, bestRank) {
+            // /hint returns a word strictly closer to the secret than best_rank
+            // (clamped to [2, vocab_size] server-side). The optional `revealed`
+            // field is intentionally omitted. best_rank is left out until we have a
+            // finite best, so the server returns a far first hint.
+            const body = { token: gameId };
+            if (Number.isFinite(bestRank)) body.best_rank = bestRank;
+            const result = await wordgun_request('/hint', { method: 'POST', body });
+            // { word: null } means no closer word remains.
+            return { word: result?.word ?? null, distance: result?.rank };
+        }
     }
 };
 
@@ -251,6 +270,12 @@ function getActiveBackend() {
 
 function backend_supports_tips() {
     return !!getActiveBackend().supportsTips;
+}
+
+// The worst/initial rank for the active backend — used to seed best_found_distance
+// so the first real guess always improves on it.
+function backend_max_distance() {
+    return getActiveBackend().maxDistance;
 }
 
 // Score a guess with the active backend. Returns { distance }: a positive number

--- a/js/api.js
+++ b/js/api.js
@@ -115,24 +115,64 @@ async function sendWebhookEvent(event = '', data = {}) {
     }
 }
 
-async function generate_secret_word() {
-    let room_id;
-    let is_bugged = true;
-    let retry_count = 0;
-    const max_retries = 5;
+// --- Game backends ----------------------------------------------------------
+// Slovotron can talk to two stateless word-guessing backends. Each one exposes
+// the same interface so the rest of the game stays backend-agnostic:
+//   createGame()          -> { gameId, secretWord }
+//   score(gameId, word)   -> { distance }   (distance falsy => not in vocabulary)
+//   tip(gameId, lastRank) -> { word, distance }   (optional; null if unsupported)
 
-    while (is_bugged) {
-        if (retry_count >= max_retries) {
-            show_fullscreen_error('Ошибка получения секретного слова.<br>Пожалуйста, попробуйте зайти позже.');
-            throw new Error('Превышено количество попыток получения секретного слова.');
+const WORDGUN_BASE_URL = 'https://api.wordgun.ru/v1';
+
+async function wordgun_request(path, { method = 'GET', body = null } = {}) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    try {
+        const response = await fetch(`${WORDGUN_BASE_URL}${path}`, {
+            method,
+            signal: controller.signal,
+            headers: {
+                'Accept': 'application/json',
+                ...(body ? { 'Content-Type': 'application/json' } : {})
+            },
+            body: body ? JSON.stringify(body) : undefined
+        });
+
+        if (!response.ok) {
+            let errorBody = null;
+            try { errorBody = await response.json(); } catch {}
+            const error = new Error(`Wordgun HTTP ${response.status}: ${errorBody?.error || response.statusText}`);
+            error.status = response.status;
+            error.code = errorBody?.code;
+            throw error;
         }
 
-        const data = await kontekstno_query({ method: 'random-challenge' });
-        room_id = data.id;
+        return await response.json();
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            throw new Error('Таймаут запроса к Wordgun API');
+        }
+        throw error;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
 
-        // Проверка на забагованное слово.
-        // Если для "банан" возвращается 0, значит игра сломана и надо перезапустить.
-        try {
+const GAME_BACKENDS = {
+    // контекстно.рф — original backend. Opaque challenge_id, "distance" score,
+    // supports hint words via the tip endpoint and discloses the secret word.
+    kontekstno: {
+        id: 'kontekstno',
+        label: 'контекстно.рф',
+        supportsTips: true,
+
+        async createGame() {
+            const data = await kontekstno_query({ method: 'random-challenge' });
+            const room_id = data.id;
+
+            // Проверка на забагованное слово.
+            // Если для "банан" возвращается 0, значит игра сломана и надо перезапустить.
             const check = await kontekstno_query({
                 method: 'score',
                 word: 'банан',
@@ -140,36 +180,115 @@ async function generate_secret_word() {
             });
 
             if (check.distance === 0) {
-                console.warn(`Слово ID ${room_id} забаговано (дистанция для "банан" = 0). Попытка ${retry_count + 1}/${max_retries}...`);
-                retry_count++;
-            } else {
-                let secret_word = null;
-                try {
-                    const secretWordResponse = await kontekstno_query({
-                        method: 'tip',
-                        challenge_id: room_id,
-                        last_word_rank: 1
-                    });
-                    secret_word = secretWordResponse?.word || null;
-                } catch (secretWordError) {
-                    console.warn('Не удалось получить секретное слово через tip(last_word_rank=1):', secretWordError);
-                }
-
-                current_secret_word_data = {
-                    challenge_id: room_id,
-                    secret_word: secret_word
-                };
-                is_bugged = false;
+                throw new Error(`Слово ID ${room_id} забаговано (дистанция для "банан" = 0).`);
             }
+
+            let secret_word = null;
+            try {
+                const secretWordResponse = await kontekstno_query({
+                    method: 'tip',
+                    challenge_id: room_id,
+                    last_word_rank: 1
+                });
+                secret_word = secretWordResponse?.word || null;
+            } catch (secretWordError) {
+                console.warn('Не удалось получить секретное слово через tip(last_word_rank=1):', secretWordError);
+            }
+
+            return { gameId: room_id, secretWord: secret_word };
+        },
+
+        async score(gameId, word) {
+            const result = await kontekstno_query({
+                method: 'score',
+                word: word,
+                challenge_id: gameId
+            });
+            return { distance: result.distance };
+        },
+
+        async tip(gameId, lastRank) {
+            const result = await kontekstno_query({
+                method: 'tip',
+                challenge_id: gameId,
+                last_word_rank: lastRank
+            });
+            return { word: result?.word, distance: result?.distance };
+        }
+    },
+
+    // wordgun.ru — stateless API (see public-api-v1.md). The game lives inside an
+    // opaque token; a guess returns { in_vocab, rank }. No hint endpoint and the
+    // secret word is never disclosed.
+    wordgun: {
+        id: 'wordgun',
+        label: 'wordgun.ru',
+        supportsTips: false,
+
+        async createGame() {
+            const data = await wordgun_request('/games', { method: 'POST' });
+            // Wordgun never reveals the secret word, so it stays null.
+            return { gameId: data.token, secretWord: null };
+        },
+
+        async score(gameId, word) {
+            const result = await wordgun_request('/guess', {
+                method: 'POST',
+                body: { token: gameId, word: word }
+            });
+            // Normalize to the shared { distance } shape: rank is the distance,
+            // an out-of-vocabulary guess has no distance.
+            return { distance: result.in_vocab ? result.rank : undefined };
+        },
+
+        tip: null
+    }
+};
+
+function getActiveBackend() {
+    return GAME_BACKENDS[game_backend] || GAME_BACKENDS.kontekstno;
+}
+
+function backend_supports_tips() {
+    return !!getActiveBackend().supportsTips;
+}
+
+// Score a guess with the active backend. Returns { distance }: a positive number
+// when the word is in vocabulary, undefined otherwise.
+async function score_word(word, gameId) {
+    return getActiveBackend().score(gameId, word);
+}
+
+// Request a hint word from the active backend, or null if it has no tip support.
+async function get_tip(gameId, lastRank) {
+    const backend = getActiveBackend();
+    if (typeof backend.tip !== 'function') return null;
+    return backend.tip(gameId, lastRank);
+}
+
+async function generate_secret_word() {
+    const backend = getActiveBackend();
+    let retry_count = 0;
+    const max_retries = 5;
+
+    while (retry_count < max_retries) {
+        try {
+            const game = await backend.createGame();
+            current_secret_word_data = {
+                challenge_id: game.gameId,
+                secret_word: game.secretWord ?? null
+            };
+            return game.gameId;
         } catch (e) {
-            console.error('Ошибка при проверке слова на баг:', e);
+            console.warn(`Не удалось создать игру (${backend.id}). Попытка ${retry_count + 1}/${max_retries}:`, e);
             retry_count++;
             // Небольшая пауза перед повтором при сетевой ошибке
             await new Promise(resolve => setTimeout(resolve, 1000));
         }
     }
 
-    return room_id;
+    show_fullscreen_error('Ошибка получения секретного слова.<br>Пожалуйста, попробуйте зайти позже.');
+    throw new Error('Превышено количество попыток получения секретного слова.');
 }
 
 function show_fullscreen_error(message) {

--- a/js/api.js
+++ b/js/api.js
@@ -236,6 +236,9 @@ const GAME_BACKENDS = {
 
         async createGame() {
             const data = await wordgun_request('/games', { method: 'POST' });
+            if (!data?.token) {
+                throw new Error('Wordgun API не вернул токен игры');
+            }
             // Wordgun never reveals the secret word, so it stays null.
             return { gameId: data.token, secretWord: null };
         },

--- a/js/confetti.js
+++ b/js/confetti.js
@@ -3,12 +3,22 @@ function randomInRange(min, max) {
   return Math.random() * (max - min) + min;
 }
 
+let confettiWinInterval = null;
+let confettiFireworksInterval = null;
+
+// Stop any running confetti/fireworks loops immediately (used on round reset).
+function stop_confetti() {
+  clearInterval(confettiWinInterval);
+  clearInterval(confettiFireworksInterval);
+}
+
 const confetti_win = (endtime) => {
-  const interval = setInterval(function () {
+  clearInterval(confettiWinInterval);
+  confettiWinInterval = setInterval(function () {
     const defaults = { count: 3, spread: 45 };
     const timeLeft = endtime - Date.now();
     if (timeLeft <= 0 || resetTimerPaused) {
-      return clearInterval(interval);
+      return clearInterval(confettiWinInterval);
     }
     confetti(
       Object.assign({}, defaults, {
@@ -34,11 +44,12 @@ const confetti_fireworks = (endtime) => {
     zIndex: 0,
   };
 
-  const interval = setInterval(function () {
+  clearInterval(confettiFireworksInterval);
+  confettiFireworksInterval = setInterval(function () {
     const timeLeft = endtime - Date.now();
 
     if (timeLeft <= 0 || resetTimerPaused) {
-      return clearInterval(interval);
+      return clearInterval(confettiFireworksInterval);
     }
 
     confetti(

--- a/js/config.js
+++ b/js/config.js
@@ -5,6 +5,7 @@ let win_avatar_enable = false;
 let sound_enable = true;
 let webhook_url = '';
 let webhook_secret = '';
+let game_backend = 'kontekstno'; // active word-guessing backend: 'kontekstno' | 'wordgun'
 let current_secret_word_data = null;
 
 // Состояние игры

--- a/js/config.js
+++ b/js/config.js
@@ -13,6 +13,7 @@ let secret_word_id = '';
 let words_count = 0;
 let is_game_finished = false;
 const MAX_LAST_WORDS = 20;
+const MAX_CONFETTI_MS = 30 * 1000; // cap confetti/fireworks at 30 seconds
 const kontekstno_api_tips_max_distance = 300; // апи подсказок не реагирует на число больше 300
 let best_found_distance = kontekstno_api_tips_max_distance; // контекстно API max distance
 

--- a/js/init.js
+++ b/js/init.js
@@ -25,7 +25,7 @@ function create_chat_connection(channel_name = '') {
 
         // проверка на подсказку, дальше не идем
         if (message.toLowerCase().startsWith('!подска') || message.toLowerCase().startsWith('! подска')) {
-            use_tip(user['username']);
+            if (backend_supports_tips()) use_tip(user['username']);
             return;
         }
 

--- a/js/init.js
+++ b/js/init.js
@@ -109,7 +109,7 @@ async function app() {
 
             // получение секретного слова для отгадывания
             secret_word_id = await generate_secret_word();
-            console.log('ID секретного слова: ', secret_word_id);
+            console.log('Ключ игры: ', secret_word_id);
             sendWebhookEvent('game-new', {
                 challenge_id: secret_word_id,
                 secret_word: current_secret_word_data?.secret_word || null

--- a/js/init.js
+++ b/js/init.js
@@ -84,10 +84,17 @@ function create_chat_connection(channel_name = '') {
 }
 
 async function runQueue() {
-    await process_message(wordQueue[0].user, wordQueue[0].color, wordQueue[0].msg)
-    wordQueue.shift()
-    if (wordQueue.length > 0) {
-        runQueue()
+    // Always shift the processed item, even if process_message throws.
+    // Otherwise the queue stalls forever and chat messages stop being handled.
+    while (wordQueue.length > 0) {
+        const { user, color, msg } = wordQueue[0];
+        try {
+            await process_message(user, color, msg);
+        } catch (e) {
+            console.error('process_message failed:', e);
+        } finally {
+            wordQueue.shift();
+        }
     }
 }
 

--- a/js/leaderboard.js
+++ b/js/leaderboard.js
@@ -6,10 +6,13 @@ function getLeaderboardData() {
     if (!data) return {};
     try {
         const parsed = JSON.parse(data);
-        // Corrupted or legacy storage may hold a non-object; fall back to an empty map.
-        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+        // Corrupted or legacy non-object value: drop it so we don't re-parse garbage every call.
+        localStorage.removeItem(LEADERBOARD_KEY);
+        return {};
     } catch (e) {
         console.error('Failed to parse leaderboard data, resetting:', e);
+        localStorage.removeItem(LEADERBOARD_KEY);
         return {};
     }
 }

--- a/js/leaderboard.js
+++ b/js/leaderboard.js
@@ -3,7 +3,15 @@ const LEADERBOARD_KEY = 'word_game_leaderboard';
 
 function getLeaderboardData() {
     const data = localStorage.getItem(LEADERBOARD_KEY);
-    return data ? JSON.parse(data) : {};
+    if (!data) return {};
+    try {
+        const parsed = JSON.parse(data);
+        // Corrupted or legacy storage may hold a non-object; fall back to an empty map.
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch (e) {
+        console.error('Failed to parse leaderboard data, resetting:', e);
+        return {};
+    }
 }
 
 function saveLeaderboardData(data) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -4,6 +4,7 @@ const avatarInput = document.getElementById('win-avatar-enable');
 const soundInput = document.getElementById('sound-enable');
 const saveBtn = document.getElementById('save-settings-btn');
 const obsLinkInput = document.getElementById('obs-link');
+const gameBackendInput = document.getElementById('game-backend');
 let validationTimeout;
 
 function parseBooleanSetting(value) {
@@ -40,6 +41,10 @@ function generateObsLink() {
 
     if (soundInput) {
         params.set('sound_enable', soundInput.checked ? '1' : '0');
+    }
+
+    if (gameBackendInput) {
+        params.set('backend', gameBackendInput.value);
     }
 
     if (webhook_url) {
@@ -147,6 +152,12 @@ function loadSettings() {
         if (soundInput) soundInput.checked = sound_enable;
     }
 
+    const storedBackend = urlParams.get('backend') || localStorage.getItem('game_backend');
+    if (storedBackend && GAME_BACKENDS[storedBackend]) {
+        game_backend = storedBackend;
+    }
+    if (gameBackendInput) gameBackendInput.value = game_backend;
+
     // Генерируем ссылку OBS при загрузке страницы
     generateObsLink();
 
@@ -169,6 +180,11 @@ if (saveBtn) {
 
         if (soundInput) {
             localStorage.setItem('sound_enable', soundInput.checked);
+        }
+
+        if (gameBackendInput && GAME_BACKENDS[gameBackendInput.value]) {
+            game_backend = gameBackendInput.value;
+            localStorage.setItem('game_backend', game_backend);
         }
 
         // Генерируем ссылку для OBS
@@ -265,6 +281,13 @@ if (avatarInput) {
 
 if (soundInput) {
     soundInput.addEventListener("input", () => {
+        checkFormsValidity();
+    });
+}
+
+if (gameBackendInput) {
+    gameBackendInput.addEventListener("change", () => {
+        generateObsLink();
         checkFormsValidity();
     });
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -138,8 +138,11 @@ function loadSettings() {
     }
 
     if (storedRestartTime) {
-        restart_time = parseInt(storedRestartTime, 10);
-        if (restartInput) restartInput.value = restart_time;
+        const parsed = parseInt(storedRestartTime, 10);
+        if (Number.isFinite(parsed) && parsed >= 0) {
+            restart_time = parsed;
+            if (restartInput) restartInput.value = restart_time;
+        }
     }
 
     if (storedAvatarInput !== null) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -5,6 +5,7 @@ const soundInput = document.getElementById('sound-enable');
 const saveBtn = document.getElementById('save-settings-btn');
 const obsLinkInput = document.getElementById('obs-link');
 const gameBackendInput = document.getElementById('game-backend');
+const backendWarning = document.getElementById('backend-warning');
 let validationTimeout;
 
 function parseBooleanSetting(value) {
@@ -160,6 +161,7 @@ function loadSettings() {
         game_backend = storedBackend;
     }
     if (gameBackendInput) gameBackendInput.value = game_backend;
+    updateBackendWarning();
 
     // Генерируем ссылку OBS при загрузке страницы
     generateObsLink();
@@ -288,8 +290,16 @@ if (soundInput) {
     });
 }
 
+// Show a warning when the wordgun backend is selected (it can be region-blocked from some RU IPs).
+function updateBackendWarning() {
+    if (!backendWarning) return;
+    const selected = gameBackendInput ? gameBackendInput.value : game_backend;
+    backendWarning.style.display = selected === 'wordgun' ? 'block' : 'none';
+}
+
 if (gameBackendInput) {
     gameBackendInput.addEventListener("change", () => {
+        updateBackendWarning();
         generateObsLink();
         checkFormsValidity();
     });

--- a/js/tips.js
+++ b/js/tips.js
@@ -41,6 +41,8 @@ function update_tip_progress() {
 }
 
 async function use_tip(user = '', force = false) {
+    // Tips are unavailable on backends without a hint endpoint (e.g. wordgun).
+    if (!backend_supports_tips()) return;
     // console.log('enter "use_tip"', user);
     if (user && tip_requests_users.has(user) && !force) return;
     if (!best_found_distance) best_found_distance = kontekstno_api_tips_max_distance;
@@ -83,11 +85,7 @@ async function use_tip(user = '', force = false) {
     // запрос подсказки
     let tip_word;
     try {
-        tip_word = await kontekstno_query({
-            method: 'tip',
-            challenge_id: secret_word_id,
-            last_word_rank: fine_tuned_distance
-        });
+        tip_word = await get_tip(secret_word_id, fine_tuned_distance);
     } catch (e) {
         console.error('tip query failed', e);
         abort_tip();

--- a/js/tips.js
+++ b/js/tips.js
@@ -83,6 +83,13 @@ async function use_tip(user = '', force = false) {
         abort_tip();
         return;
     }
+    // wordgun /hint returns { word: null } when no closer word remains — not an error,
+    // so give the user feedback instead of logging a misleading failure.
+    if (tip_word && tip_word.word === null) {
+        addTextToLastWords('Ближе слов для подсказки нет');
+        abort_tip();
+        return;
+    }
     if (!tip_word?.distance) {
         console.error('tip_word.distance is undefined', tip_word);
         abort_tip();

--- a/js/tips.js
+++ b/js/tips.js
@@ -41,11 +41,11 @@ function update_tip_progress() {
 }
 
 async function use_tip(user = '', force = false) {
-    // Tips are unavailable on backends without a hint endpoint (e.g. wordgun).
+    // Tips are unavailable on backends without a hint endpoint.
     if (!backend_supports_tips()) return;
     // console.log('enter "use_tip"', user);
     if (user && tip_requests_users.has(user) && !force) return;
-    if (!best_found_distance) best_found_distance = kontekstno_api_tips_max_distance;
+    if (!best_found_distance) best_found_distance = backend_max_distance();
 
     let tip_time_left = tip_cooldown_time - (Date.now() - tip_last_reset_time);
     if (tip_time_left > 0 && !force) {
@@ -73,19 +73,11 @@ async function use_tip(user = '', force = false) {
     // Play activation animation
     tip_progress_bar.classList.add('tip-activated');
 
-    // надо фейкануть дальность лучшего слова чтобы он не уполовинивал близость, а чуть подальше. Например мальтипликатор 1.5 даст 25% приближения вместо 50%
-    let fine_tuned_distance = Math.floor(best_found_distance * 1.5);
-
-    // иначе она всегда будет kontekstno_api_max_distance, это магическое число апишки, большую дальность она сбрасывает к kontekstno_api_max_distance
-    if (fine_tuned_distance > kontekstno_api_tips_max_distance) fine_tuned_distance = kontekstno_api_tips_max_distance;
-
-    // edge case. Если логика апишки (Math.ceil(fine_tuned_distance / 2)) даст такое же значение, как и текущий best_found_distance, то не фейкаем его, чтобы всё не циклилось
-    if (Math.ceil(fine_tuned_distance / 2) == best_found_distance) fine_tuned_distance = best_found_distance;
-
-    // запрос подсказки
+    // The hint request is built per-backend: kontekstno applies its own multiplier,
+    // wordgun uses best_found_distance directly as best_rank.
     let tip_word;
     try {
-        tip_word = await get_tip(secret_word_id, fine_tuned_distance);
+        tip_word = await get_tip(secret_word_id, best_found_distance);
     } catch (e) {
         console.error('tip query failed', e);
         abort_tip();

--- a/js/ws.js
+++ b/js/ws.js
@@ -249,6 +249,8 @@ function handle_win(winner_user, winning_word = '') {
     // A non-finite restart_time makes the stop check (timeLeft <= 0) never true,
     // leaving confetti/fireworks running forever — clamp to a short fallback.
     if (!Number.isFinite(confettiTimeout)) { confettiTimeout = Date.now() + 5 * 1000; }
+    // Never run confetti longer than the cap, even for huge restart_time values.
+    confettiTimeout = Math.min(confettiTimeout, Date.now() + MAX_CONFETTI_MS);
     confetti_stars(confetti_win(confettiTimeout));
     if (window.innerWidth > 1200) {
         confetti_fireworks(confettiTimeout);
@@ -303,6 +305,7 @@ async function resetRoundTimeout(time) {
 function reset_round() {
     last_words_container.innerHTML = '';
     best_match_container.innerHTML = '';
+    stop_confetti();
     // The tip mechanic only exists on backends that expose a hint endpoint.
     tip_menu_button.style.display = backend_supports_tips() ? 'block' : 'none';
     checked_words.clear();

--- a/js/ws.js
+++ b/js/ws.js
@@ -304,7 +304,7 @@ function reset_round() {
     uniqUsers.clear();
     uniqWords = repeatWords = 0;
     reset_tips();
-    best_found_distance = kontekstno_api_tips_max_distance;
+    best_found_distance = backend_max_distance();
     markOverlayActivity();
 }
 

--- a/js/ws.js
+++ b/js/ws.js
@@ -216,13 +216,16 @@ function handle_win(winner_user, winning_word = '') {
     }
 
     const winnerAvatar = document.getElementById('winner-avatar');
-    winnerAvatar.src = '';
-    // getTwitchUserData returns null on lookup failure (e.g. tip and test wins),
-    // so guard before reading user.logo to avoid a TypeError / unhandled rejection.
-    getTwitchUserData(winner_user.username).then((user) => {
-        winnerAvatar.classList.toggle('blurred', !win_avatar_enable);
-        if (user?.logo) winnerAvatar.src = user.logo;
-    }).catch((e) => console.error('avatar load failed:', e));
+    // Transparent 1x1 GIF placeholder avoids a broken-image icon when no avatar loads.
+    winnerAvatar.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+    winnerAvatar.classList.toggle('blurred', !win_avatar_enable);
+    // Only hit the Twitch API when the avatar is actually shown. getTwitchUserData
+    // returns null on lookup failure, so guard before reading user.logo.
+    if (win_avatar_enable) {
+        getTwitchUserData(winner_user.username).then((user) => {
+            if (user?.logo) winnerAvatar.src = user.logo;
+        }).catch((e) => console.error('avatar load failed:', e));
+    }
 
     const winnerBlock = document.getElementById('winner');
     winnerBlock.querySelector('.winner-name').innerText = winner_user['display-name'];

--- a/js/ws.js
+++ b/js/ws.js
@@ -221,11 +221,12 @@ function handle_win(winner_user, winning_word = '') {
 
     const winnerAvatar = document.getElementById('winner-avatar');
     winnerAvatar.src = '';
+    // getTwitchUserData returns null on lookup failure (e.g. tip and test wins),
+    // so guard before reading user.logo to avoid a TypeError / unhandled rejection.
     getTwitchUserData(winner_user.username).then((user) => {
-        console.log(user);
         winnerAvatar.classList.toggle('blurred', !win_avatar_enable);
-        winnerAvatar.src = user.logo;
-    });
+        if (user?.logo) winnerAvatar.src = user.logo;
+    }).catch((e) => console.error('avatar load failed:', e));
 
     const winnerBlock = document.getElementById('winner');
     winnerBlock.querySelector('.winner-name').innerText = winner_user['display-name'];

--- a/js/ws.js
+++ b/js/ws.js
@@ -243,6 +243,9 @@ function handle_win(winner_user, winning_word = '') {
     const resetTimeout = (typeof restart_time !== 'undefined' ? restart_time : 20) * 1000;
     let confettiTimeout = Date.now() + (restart_time - 5) * 1000;
     if (restart_time <= 10) { confettiTimeout = Date.now() + 5 * 1000 };
+    // A non-finite restart_time makes the stop check (timeLeft <= 0) never true,
+    // leaving confetti/fireworks running forever — clamp to a short fallback.
+    if (!Number.isFinite(confettiTimeout)) { confettiTimeout = Date.now() + 5 * 1000; }
     confetti_stars(confetti_win(confettiTimeout));
     if (window.innerWidth > 1200) {
         confetti_fireworks(confettiTimeout);

--- a/js/ws.js
+++ b/js/ws.js
@@ -97,14 +97,10 @@ async function process_message(user, nickname_color, word, force_win = false) {
         if (force_win) {
             word_check = { distance: 1 };
         } else {
-            word_check = await kontekstno_query({
-                method: 'score',
-                word: word,
-                challenge_id: secret_word_id
-            });
+            word_check = await score_word(word, secret_word_id);
         }
     } catch (err) {
-        console.warn('Ошибка kontekstno_query:', err);
+        console.warn('Ошибка проверки слова:', err);
         addTextToLastWords(word + ' ошибка API');
         return;
     }
@@ -301,7 +297,8 @@ async function resetRoundTimeout(time) {
 function reset_round() {
     last_words_container.innerHTML = '';
     best_match_container.innerHTML = '';
-    tip_menu_button.style.display = 'block';
+    // The tip mechanic only exists on backends that expose a hint endpoint.
+    tip_menu_button.style.display = backend_supports_tips() ? 'block' : 'none';
     checked_words.clear();
     roundStartTime = Date.now();
     uniqUsers.clear();


### PR DESCRIPTION
Набор улучшений: новая возможность выбора источника слов (бэкенда) и пакет фиксов, делающих приложение устойчивым к сбоям во время обработки сообщений и к повреждённым/неполным данным.

## ✨ Новое: выбор источника слов (бэкенда)

- **Абстракция бэкендов + селектор в настройках** (`eafc930`) — API-слой переведён на единый интерфейс, добавлен выбор «контекстно.рф / wordgun.ru». По умолчанию — контекстно. Выбор сохраняется и пробрасывается в ссылку для OBS-оверлея.
- **Подсказки для wordgun** (`98647de`) — поддержка через эндпоинт `/v1/hint`; семантика рангов wordgun разведена с множителем контекстно, инициализация «лучшей дистанции» сделана зависимой от бэкенда.
- **Стиль выпадающего списка** (`f301477`) — селект бэкенда оформлен под остальные поля настроек (тёмная тема, своя стрелка).
- **Предупреждение про регион** (`e9449fc`) — при выборе wordgun.ru показывается уведомление, что бэкенд может работать некорректно с российских IP-адресов (с подсказкой про VPN или переключение на контекстно.рф).

## 🐛 Устойчивость к сбоям

- **Очередь слов не виснет при исключении** (`c95b958`) — если `process_message` бросает ошибку, очередь продолжает работать, а не зависает навсегда.
- **Защита таблицы лидеров** (`d912b95`, `e90649e`) — безопасный парсинг `localStorage`; повреждённые данные не ломают рендер и удаляются, чтобы не вызывать ошибку при каждом обновлении.
- **Защита аватара победителя** (`70a0d65`, `e90649e`) — корректная обработка отсутствующих данных Twitch (без TypeError), прозрачный плейсхолдер вместо «битой картинки», а запрос к Twitch API не делается, если аватар отключён.
- **Конфетти и фейерверк** (`5394a08`, `d312ce8`) — больше не зацикливаются при нечисловом `restart_time`, принудительно гасятся при старте нового раунда (не «перетекают» в следующую игру) и ограничены максимум 30 секундами.
- **Подсказка без ближайших слов** (`e90649e`) — когда у wordgun нет более близкого слова (`{word: null}`), показывается понятное сообщение вместо ложной ошибки в консоль.

## 🧹 Прочее

- **`.idea` в `.gitignore`** (`86eeba4`) — исключены файлы конфигурации IDE.
- **Понятный лог ключа игры** (`20cfc8d`) — переименован вводящий в заблуждение лог «ID секретного слова» → «Ключ игры» (значение — токен/ключ, а не ID слова).
- **Актуализация комментария** (`831ac26`) — убрано упоминание удалённого из API поля `revealed`.

feature + bugfix

---
Замечания из ревью Gemini (PR #120 и #121) учтены: очистка повреждённого
`localStorage`, плейсхолдер аватара, пропуск запроса при выключенной аватарке,
обработка пустой подсказки wordgun.